### PR TITLE
Reduce amount of github actions run

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -14,8 +14,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python: ["3.10", "3.11", "3.12"]
+        os: [ubuntu-latest, windows-latest]
+        python: ["3.10", "3.12"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
As my account is somewhat close to the limit and if it hits it before the end of the month actions won't be run anymore. The reduced actions should still be fine, and this will help prevent hitting the limits in the future as well.